### PR TITLE
When an authenticated service was disconnect abruptly mid friend request...

### DIFF
--- a/app/models/social_auth/facebook_service.rb
+++ b/app/models/social_auth/facebook_service.rb
@@ -52,7 +52,7 @@ module SocialAuth
       friend_ids
 
     rescue InvalidToken => e
-      disconnect
+      disconnect(e)
       return []
     end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -100,17 +100,19 @@ module SocialAuth
         @service.update(method: 'Authenticated')
         expect{
           @service.disconnect
-        }.to change(Service, :count).by(0)
+        }.to raise_error InvalidToken
       end
 
       it "hits service disconnected callback if callback is true" do
+        @service.update(method: 'Connected')
         expect_any_instance_of(User).to receive(:service_disconnected_callback).once
         @service.disconnect
       end
 
       it "doesn't hit service disconnected callback if callback is false" do
+        @service.update(method: 'Connected')
         expect_any_instance_of(User).to_not receive(:service_disconnected_callback).once
-        @service.disconnect(false)
+        @service.disconnect(nil, false)
       end
     end
 


### PR DESCRIPTION
... it would simply catch the exception and do nothing. We know re-raise the exception so it can be delt with at the app level